### PR TITLE
[DPM-124] Refactor: `rand_u*` -> `cut_to<>`

### DIFF
--- a/examples/proto_dice/contracts/src/proto_dice.cpp
+++ b/examples/proto_dice/contracts/src/proto_dice.cpp
@@ -55,7 +55,7 @@ void proto_dice::on_action(uint64_t ses_id, uint16_t type, std::vector<uint32_t>
 void proto_dice::on_random(uint64_t ses_id, checksum256 rand) {
     const auto& roll = rolls.get(ses_id);
     const auto& session = get_session(ses_id);
-    uint32_t rand_number = rand_u64(rand) % 100;
+    uint32_t rand_number = cut_to<uint32_t>(rand) % 100;
 
     eosio::print("rand num: ", rand_number, "\n");
 

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -170,7 +170,7 @@ protected:
 
 protected:
     /* utility helpers */
-    template<typename T, bool = std::is_unsigned<T>::value>
+    template<typename T, class = std::enable_if_t<std::is_unsigned<T>::value>>
     T cut_to(const checksum256& input) const {
         return cut_to<uint128_t>(input) % std::numeric_limits<T>::max();
     }

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -171,12 +171,12 @@ protected:
 protected:
     /* utility helpers */
     template<typename T, bool = std::is_unsigned<T>::value>
-    static T cut_to(const checksum256& input) {
+    T cut_to(const checksum256& input) const {
         return cut_to<uint128_t>(input) % std::numeric_limits<T>::max();
     }
 
     template<>
-    static uint128_t cut_to(const checksum256& input) {
+    uint128_t cut_to(const checksum256& input) const {
         const auto& parts = input.get_array();
         const uint128_t left = parts[0] % std::numeric_limits<uint64_t>::max();
         const uint128_t right = parts[1] % std::numeric_limits<uint64_t>::max();

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -169,20 +169,18 @@ protected:
 
 protected:
     /* utility helpers */
-    uint128_t rand_u128(const checksum256& rand) const {
-        const auto& arr = rand.get_array();
-        // use % operation to save original distribution
-        const uint128_t left = arr[0] % UINT64_MAX;
-        const uint128_t right = arr[1] % UINT64_MAX;
+    template<typename T>
+    static T cut_to(const checksum256& input) {
+        T result;
+        uint8_t byte_limit = sizeof(T);
 
-        // just concat parts
-        // it's not fair way(don't save original distribution), but more simpler
-        return (left << 64) & right;
-    }
+        for (const auto & byte: input.extract_as_byte_array()) {
+            result = (result | byte) << sizeof(byte) * 8;
+            if (--byte_limit == 0)
+                break;
+        }
 
-    uint64_t rand_u64(const checksum256& rand) const {
-        auto u128 = rand_u128(rand);
-        return u128 % UINT64_MAX;
+        return result;
     }
 
 protected:


### PR DESCRIPTION
Right now - only manual check. After [DPM-126][DPM-127][DPM-128] - normal unit tests

[DPM-126]: https://daocasino.atlassian.net/browse/DPM-126
[DPM-127]: https://daocasino.atlassian.net/browse/DPM-127
[DPM-128]: https://daocasino.atlassian.net/browse/DPM-128