### PR TITLE
[DPM-127] mock random

### DIFF
--- a/cicd/test.sh
+++ b/cicd/test.sh
@@ -4,36 +4,6 @@ set -o pipefail
 
 . "${BASH_SOURCE[0]%/*}/utils.sh"
 
-is_debug=y
-
-usage() {
-  echo "Test contracts."
-  echo
-  echo "Usage:"
-  echo
-  echo "  $PROGNAME [ OPTIONS ]"
-  echo
-  echo "Options:"
-  echo
-  echo "  --release              : is release"
-  echo
-  echo "  -h, --help           : print this message"
-}
-
-OPTS="$( getopt -o "h" -l "\
-release,\
-help" -n "$PROGNAME" -- "$@" )"
-eval set -- "$OPTS"
-while true; do
-  case "${1:-}" in
-  (--release)      is_debug=n      ; shift   ; readonly is_debug ;;
-  (-h|--help)      usage ; exit 0 ;;
-  (--)             shift ; break ;;
-  (*)              die "Invalid option: ${1:-}." ;;
-  esac
-done
-unset OPTS
-
 log "=========== Running unit tests ==========="
 
 (

--- a/cicd/test.sh
+++ b/cicd/test.sh
@@ -4,6 +4,36 @@ set -o pipefail
 
 . "${BASH_SOURCE[0]%/*}/utils.sh"
 
+is_debug=y
+
+usage() {
+  echo "Test contracts."
+  echo
+  echo "Usage:"
+  echo
+  echo "  $PROGNAME [ OPTIONS ]"
+  echo
+  echo "Options:"
+  echo
+  echo "  --release              : is release"
+  echo
+  echo "  -h, --help           : print this message"
+}
+
+OPTS="$( getopt -o "h" -l "\
+release,\
+help" -n "$PROGNAME" -- "$@" )"
+eval set -- "$OPTS"
+while true; do
+  case "${1:-}" in
+  (--release)      is_debug=n      ; shift   ; readonly is_debug ;;
+  (-h|--help)      usage ; exit 0 ;;
+  (--)             shift ; break ;;
+  (*)              die "Invalid option: ${1:-}." ;;
+  esac
+done
+unset OPTS
+
 log "=========== Running unit tests ==========="
 
 (

--- a/cicd/test.sh
+++ b/cicd/test.sh
@@ -10,6 +10,6 @@ log "=========== Running unit tests ==========="
     tests=$(find ./build/examples/*/tests/ -maxdepth 1 -name "*_unit_test")
     for unit_test in $tests; do
         log "Running $unit_test..."
-        $unit_test
+        $unit_test $@
     done
 )

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,7 +1,13 @@
 macro(add_game_contract TARGET)
     add_executable(${TARGET} ${ARGN})
     target_compile_options(${TARGET} PUBLIC -contract=${TARGET} -DNOABI)
+
+    if(IS_DEBUG)
+        target_compile_options(${TARGET} PUBLIC -DIS_DEBUG=on)
+    endif()
+
     target_link_libraries(${TARGET} game-contract-sdk)
+
     add_custom_command(TARGET ${TARGET} POST_BUILD
         COMMAND python3
             ${GAME_SDK_PATH}/sdk/scripts/abi-merger.py
@@ -9,6 +15,17 @@ macro(add_game_contract TARGET)
             ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.abi
             ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.abi
     )
+
+    if(IS_DEBUG)
+        add_custom_command(TARGET ${TARGET} POST_BUILD
+            COMMAND python3
+                ${GAME_SDK_PATH}/sdk/scripts/abi-merger.py
+                ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.abi
+                ${GAME_SDK_PATH}/sdk/files/debug.abi
+                ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.abi
+        )
+    endif()
+
 endmacro()
 
 macro(load_daobet_contracts VERSION)
@@ -50,8 +67,6 @@ macro(add_game_test TARGET)
     if(IS_DEBUG)
         target_compile_options(${TARGET} PUBLIC -DIS_DEBUG=on)
     endif()
-
-    unset(IS_DEBUG CACHE)
 
     target_link_libraries(${TARGET} game-tester)
 endmacro()

--- a/examples/proto_dice/contracts/src/proto_dice.cpp
+++ b/examples/proto_dice/contracts/src/proto_dice.cpp
@@ -59,6 +59,8 @@ void proto_dice::on_random(uint64_t ses_id, checksum256 rand) {
     const auto& session = get_session(ses_id);
     const auto rand_number = service::cut_to<uint32_t>(rand) % 100;
 
+    send_game_message(std::vector<game_sdk::param_t> { rand_number });
+
     eosio::print("rand num: ", rand_number, "\n");
 
     if (roll.number >= rand_number) { // Loose

--- a/examples/proto_dice/contracts/src/proto_dice.cpp
+++ b/examples/proto_dice/contracts/src/proto_dice.cpp
@@ -59,8 +59,6 @@ void proto_dice::on_random(uint64_t ses_id, checksum256 rand) {
     const auto& session = get_session(ses_id);
     const auto rand_number = service::cut_to<uint32_t>(rand) % 100;
 
-    send_game_message(std::vector<game_sdk::param_t>{rand_number});
-
     eosio::print("rand num: ", rand_number, "\n");
 
     if (roll.number >= rand_number) { // Loose
@@ -68,7 +66,7 @@ void proto_dice::on_random(uint64_t ses_id, checksum256 rand) {
         return;
     }
 
-    finish_game(calc_max_win(ses_id, roll.number));
+    finish_game(calc_max_win(ses_id, roll.number), std::vector<game_sdk::param_t> { rand_number });
 }
 
 void proto_dice::on_finish(uint64_t ses_id) {

--- a/examples/proto_dice/contracts/src/proto_dice.cpp
+++ b/examples/proto_dice/contracts/src/proto_dice.cpp
@@ -59,7 +59,7 @@ void proto_dice::on_random(uint64_t ses_id, checksum256 rand) {
     const auto& session = get_session(ses_id);
     const auto rand_number = service::cut_to<uint32_t>(rand) % 100;
 
-    send_game_message(std::vector<game_sdk::param_t> { rand_number });
+    send_game_message(std::vector<game_sdk::param_t>{rand_number});
 
     eosio::print("rand num: ", rand_number, "\n");
 

--- a/examples/proto_dice/tests/proto_dice_tests.cpp
+++ b/examples/proto_dice/tests/proto_dice_tests.cpp
@@ -177,6 +177,46 @@ BOOST_FIXTURE_TEST_CASE(full_session_success_test, proto_dice_tester) try {
 }
 FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE(full_session_pseudo_test, proto_dice_tester) try {
+    auto player_name = N(player);
+
+    create_player(player_name);
+    link_game(player_name, game_name);
+
+    transfer(N(eosio), player_name, STRSYM("10.0000"));
+    transfer(N(eosio), casino_name, STRSYM("1000.0000"));
+
+    const auto player_balance_before = get_balance(player_name);
+
+    auto ses_id = new_game_session(game_name, player_name, casino_id, STRSYM("5.0000"));
+
+    BOOST_REQUIRE_EQUAL(get_balance(game_name), STRSYM("5.0000"));
+
+    push_next_random(
+        game_name,
+        sha256("0000000000000000000000000000000000000000000000000000000000000063") // 99
+    );
+
+    game_action(game_name, ses_id, 0, {98});
+
+    auto session = get_game_session(game_name, ses_id);
+    BOOST_REQUIRE_EQUAL(
+        session["state"].as<uint32_t>(),
+        3
+    ); // req_signidice_part_1 state
+
+    signidice(game_name, ses_id);
+
+    const auto player_balance_after = get_balance(player_name);
+
+    session = get_game_session(game_name, ses_id);
+    BOOST_REQUIRE_EQUAL(session.is_null(), true);
+
+    const auto payout = asset(100000, symbol(CORE_SYM)); // 10 token with 98
+    BOOST_REQUIRE_EQUAL(player_balance_before + payout, player_balance_after);
+}
+FC_LOG_AND_RETHROW()
+
 BOOST_FIXTURE_TEST_CASE(session_exiration_test, proto_dice_tester) try {
     auto player_name = N(player);
 

--- a/examples/proto_dice/tests/proto_dice_tests.cpp
+++ b/examples/proto_dice/tests/proto_dice_tests.cpp
@@ -193,18 +193,15 @@ BOOST_FIXTURE_TEST_CASE(full_session_pseudo_test, proto_dice_tester) try {
 
     BOOST_REQUIRE_EQUAL(get_balance(game_name), STRSYM("5.0000"));
 
-    push_next_random(
-        game_name,
-        sha256("0000000000000000000000000000000000000000000000000000000000000063") // 99
+    push_next_random(game_name,
+                     sha256("0000000000000000000000000000000000000000000000000000000000000063") // 99
     );
 
     game_action(game_name, ses_id, 0, {98});
 
     auto session = get_game_session(game_name, ses_id);
-    BOOST_REQUIRE_EQUAL(
-        session["state"].as<uint32_t>(),
-        3
-    ); // req_signidice_part_1 state
+    BOOST_REQUIRE_EQUAL(session["state"].as<uint32_t>(),
+                        3); // req_signidice_part_1 state
 
     signidice(game_name, ses_id);
 

--- a/examples/proto_dice/tests/proto_dice_tests.cpp
+++ b/examples/proto_dice/tests/proto_dice_tests.cpp
@@ -177,6 +177,7 @@ BOOST_FIXTURE_TEST_CASE(full_session_success_test, proto_dice_tester) try {
 }
 FC_LOG_AND_RETHROW()
 
+#ifdef IS_DEBUG
 BOOST_FIXTURE_TEST_CASE(full_session_pseudo_test, proto_dice_tester) try {
     auto player_name = N(player);
 
@@ -216,6 +217,7 @@ BOOST_FIXTURE_TEST_CASE(full_session_pseudo_test, proto_dice_tester) try {
     BOOST_REQUIRE_EQUAL(player_balance_before + payout, player_balance_after);
 }
 FC_LOG_AND_RETHROW()
+#endif
 
 BOOST_FIXTURE_TEST_CASE(session_exiration_test, proto_dice_tester) try {
     auto player_name = N(player);

--- a/examples/stub/CMakeLists.txt
+++ b/examples/stub/CMakeLists.txt
@@ -7,6 +7,8 @@ include(ExternalProject)
 set(EOSIO_WASM_OLD_BEHAVIOR "Off")
 find_package(eosio.cdt)
 
+option(IS_DEBUG "Is Debug" OFF)
+
 set(GAME_SDK_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../) # Path to game SDK project root
 
 message(STATUS "Building stub example contract")
@@ -17,6 +19,7 @@ ExternalProject_Add(
     CMAKE_ARGS
         -DCMAKE_TOOLCHAIN_FILE=${EOSIO_CDT_ROOT}/lib/cmake/eosio.cdt/EosioWasmToolchain.cmake
         -DGAME_SDK_PATH=${GAME_SDK_PATH}
+        -DIS_DEBUG=${IS_DEBUG}
     PATCH_COMMAND ""
     TEST_COMMAND ""
     INSTALL_COMMAND ""
@@ -40,6 +43,7 @@ ExternalProject_Add(
         -DLLVM_DIR=${LLVM_DIR}
         -Deosio_DIR=${CMAKE_MODULE_PATH}
         -DGAME_SDK_PATH=${GAME_SDK_PATH}
+        -DIS_DEBUG=${IS_DEBUG}
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tests
     BUILD_ALWAYS 1

--- a/examples/stub/tests/stub_tests.cpp
+++ b/examples/stub/tests/stub_tests.cpp
@@ -83,6 +83,7 @@ BOOST_FIXTURE_TEST_CASE(full_session_pseudo_random_test, stub_tester) try {
     auto player_name = N(player);
 
     push_next_random(game_name, sha256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+    push_to_prng(game_name, 0xffffffffffffffff);
 
     create_player(player_name);
     link_game(player_name, game_name);

--- a/examples/stub/tests/stub_tests.cpp
+++ b/examples/stub/tests/stub_tests.cpp
@@ -32,7 +32,7 @@ BOOST_FIXTURE_TEST_CASE(new_session_test, stub_tester) try {
 
     auto player_bet = STRSYM("5.0000");
     auto ses_id = new_game_session(game_name, player_name, casino_id, player_bet);
-auto session = get_game_session(game_name, ses_id);
+    auto session = get_game_session(game_name, ses_id);
 
     BOOST_REQUIRE_EQUAL(session["req_id"].as<uint64_t>(), ses_id);
     BOOST_REQUIRE_EQUAL(session["casino_id"].as<uint64_t>(), casino_id);

--- a/examples/stub/tests/stub_tests.cpp
+++ b/examples/stub/tests/stub_tests.cpp
@@ -302,15 +302,20 @@ BOOST_FIXTURE_TEST_CASE(game_action_bad_state_test, stub_tester) try {
                 ("type", 0)
                 ("params", std::vector<uint32_t>{30})
         ), wasm_assert_msg("state should be 'req_deposit' or 'req_action'"));
-    // clang-format on
 
     auto digest = get_game_session(game_name, ses_id)["digest"].as<sha256>();
     auto sign_1 = rsa_sign(rsa_keys.at(platform_name), digest);
-    BOOST_REQUIRE_EQUAL(
-        push_action(game_name, N(sgdicefirst), {platform_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_1)),
-        success());
 
-    // clang-format off
+    BOOST_REQUIRE_EQUAL(
+        push_action(
+            game_name,
+            N(sgdicefirst),
+            {platform_name, N(signidice)},
+            mvo()
+                ("req_id", ses_id)
+                ("sign", sign_1)
+        ), success());
+
     BOOST_REQUIRE_EQUAL(
         push_action(
             game_name,
@@ -340,20 +345,39 @@ BOOST_FIXTURE_TEST_CASE(signidice_1_bad_state_test, stub_tester) try {
 
     auto digest = get_game_session(game_name, ses_id)["digest"].as<sha256>();
     auto sign_1 = rsa_sign(rsa_keys.at(platform_name), digest);
-    // clang-format on
+    
+    // clang-format off
     BOOST_REQUIRE_EQUAL(
-        push_action(game_name, N(sgdicefirst), {platform_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_1)),
-        wasm_assert_msg("state should be 'req_signidice_part_1'"));
+        push_action(
+            game_name,
+            N(sgdicefirst),
+            {platform_name, N(signidice)},
+            mvo()
+                ("req_id", ses_id)
+                ("sign", sign_1)
+        ), wasm_assert_msg("state should be 'req_signidice_part_1'"));
 
     game_action(game_name, ses_id, 0, {30});
 
     BOOST_REQUIRE_EQUAL(
-        push_action(game_name, N(sgdicefirst), {platform_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_1)),
-        success());
+        push_action(
+            game_name,
+            N(sgdicefirst),
+            {platform_name, N(signidice)},
+            mvo()
+                ("req_id", ses_id)
+                ("sign", sign_1)
+        ), success());
 
     BOOST_REQUIRE_EQUAL(
-        push_action(game_name, N(sgdicefirst), {platform_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_1)),
-        wasm_assert_msg("state should be 'req_signidice_part_1'"));
+        push_action(
+            game_name,
+            N(sgdicefirst),
+            {platform_name, N(signidice)},
+            mvo()
+                ("req_id", ses_id)
+                ("sign", sign_1)
+        ), wasm_assert_msg("state should be 'req_signidice_part_1'"));
     // clang-format on
 }
 FC_LOG_AND_RETHROW()
@@ -372,6 +396,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_2_bad_state_test, stub_tester) try {
 
     auto digest = get_game_session(game_name, ses_id)["digest"].as<sha256>();
     auto sign = rsa_sign(rsa_keys.at(platform_name), digest);
+    
     // clang-format off
     BOOST_REQUIRE_EQUAL(
         push_action(

--- a/examples/stub/tests/stub_tests.cpp
+++ b/examples/stub/tests/stub_tests.cpp
@@ -78,6 +78,7 @@ BOOST_FIXTURE_TEST_CASE(full_session_success_test, stub_tester) try {
 }
 FC_LOG_AND_RETHROW()
 
+#ifdef IS_DEBUG
 BOOST_FIXTURE_TEST_CASE(full_session_pseudo_random_test, stub_tester) try {
     auto player_name = N(player);
 
@@ -114,6 +115,7 @@ BOOST_FIXTURE_TEST_CASE(full_session_pseudo_random_test, stub_tester) try {
     BOOST_REQUIRE_EQUAL(casino_balance_before + player_bet, casino_balance_after);
 }
 FC_LOG_AND_RETHROW()
+#endif
 
 BOOST_FIXTURE_TEST_CASE(session_exiration_test, stub_tester) try {
     auto player_name = N(player);

--- a/examples/stub/tests/stub_tests.cpp
+++ b/examples/stub/tests/stub_tests.cpp
@@ -32,8 +32,7 @@ BOOST_FIXTURE_TEST_CASE(new_session_test, stub_tester) try {
 
     auto player_bet = STRSYM("5.0000");
     auto ses_id = new_game_session(game_name, player_name, casino_id, player_bet);
-
-    auto session = get_game_session(game_name, ses_id);
+auto session = get_game_session(game_name, ses_id);
 
     BOOST_REQUIRE_EQUAL(session["req_id"].as<uint64_t>(), ses_id);
     BOOST_REQUIRE_EQUAL(session["casino_id"].as<uint64_t>(), casino_id);

--- a/examples/stub/tests/stub_tests.cpp
+++ b/examples/stub/tests/stub_tests.cpp
@@ -15,7 +15,8 @@ class stub_tester : public game_tester {
 
         game_params_type game_params = {};
         deploy_game<stub_game>(game_name, game_params);
-    } };
+    }
+};
 
 const name stub_tester::game_name = N(stubgame);
 
@@ -80,10 +81,7 @@ FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE(full_session_pseudo_random_test, stub_tester) try {
     auto player_name = N(player);
 
-    push_next_random(
-        game_name,
-        sha256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-    );
+    push_next_random(game_name, sha256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
     create_player(player_name);
     link_game(player_name, game_name);
@@ -341,36 +339,18 @@ BOOST_FIXTURE_TEST_CASE(signidice_1_bad_state_test, stub_tester) try {
     auto sign_1 = rsa_sign(rsa_keys.at(platform_name), digest);
     // clang-format on
     BOOST_REQUIRE_EQUAL(
-        push_action(
-            game_name,
-            N(sgdicefirst),
-            {platform_name, N(signidice)},
-            mvo()
-                ("req_id", ses_id)
-                ("sign", sign_1)
-        ), wasm_assert_msg("state should be 'req_signidice_part_1'"));
+        push_action(game_name, N(sgdicefirst), {platform_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_1)),
+        wasm_assert_msg("state should be 'req_signidice_part_1'"));
 
     game_action(game_name, ses_id, 0, {30});
 
     BOOST_REQUIRE_EQUAL(
-        push_action(
-            game_name,
-            N(sgdicefirst),
-            {platform_name, N(signidice)},
-            mvo()
-                ("req_id", ses_id)
-                ("sign", sign_1)
-        ), success());
+        push_action(game_name, N(sgdicefirst), {platform_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_1)),
+        success());
 
     BOOST_REQUIRE_EQUAL(
-        push_action(
-            game_name,
-            N(sgdicefirst),
-            {platform_name, N(signidice)},
-            mvo()
-                ("req_id", ses_id)
-                ("sign", sign_1)
-        ), wasm_assert_msg("state should be 'req_signidice_part_1'"));
+        push_action(game_name, N(sgdicefirst), {platform_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_1)),
+        wasm_assert_msg("state should be 'req_signidice_part_1'"));
     // clang-format on
 }
 FC_LOG_AND_RETHROW()

--- a/sdk/files/debug.abi
+++ b/sdk/files/debug.abi
@@ -1,0 +1,18 @@
+{
+    "actions": [
+        {
+            "name": "pushnrandom",
+            "type": "push_next_random",
+            "ricardian_contract": ""
+        }
+    ],
+    "tables": [
+        {
+            "name": "debug",
+            "type": "debug_table",
+            "index_type": "i64",
+            "key_names": [],
+            "key_types": []
+        }
+    ]
+}

--- a/sdk/files/debug.abi
+++ b/sdk/files/debug.abi
@@ -1,4 +1,26 @@
 {
+    "structs": [
+        {
+            "name": "push_next_random",
+            "base": "",
+            "fields": [
+                {
+                    "name": "next_random",
+                    "type": "checksum256"
+                }
+            ]
+        },
+        {
+            "name": "debug_table",
+            "base": "",
+            "fields": [
+                {
+                    "name": "pseudo_queue",
+                    "type": "checksum256[]"
+                }
+            ]
+        }
+    ],
     "actions": [
         {
             "name": "pushnrandom",

--- a/sdk/files/debug.abi
+++ b/sdk/files/debug.abi
@@ -11,12 +11,26 @@
             ]
         },
         {
+            "name": "push_to_prng",
+            "base": "",
+            "fields": [
+                {
+                    "name": "next_random",
+                    "type": "uint64"
+                }
+            ]
+        },
+        {
             "name": "debug_table",
             "base": "",
             "fields": [
                 {
                     "name": "pseudo_queue",
                     "type": "checksum256[]"
+                },
+                {
+                    "name": "pseudo_prng",
+                    "type": "uint64[]"
                 }
             ]
         }
@@ -25,6 +39,11 @@
         {
             "name": "pushnrandom",
             "type": "push_next_random",
+            "ricardian_contract": ""
+        },
+        {
+            "name": "pushprng",
+            "type": "push_to_prng",
             "ricardian_contract": ""
         }
     ],

--- a/sdk/include/game-contract-sdk/dispatcher.hpp
+++ b/sdk/include/game-contract-sdk/dispatcher.hpp
@@ -63,6 +63,8 @@ bool execute_action(eosio::name self, eosio::name code, void (game::*func)(Args.
             case "close"_n.value:                                                                                      \
                 game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::close);                \
                 break;                                                                                                 \
+            case "pushnrandom"_n.value:                                                                                \
+                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::push_next_random);     \
             default:                                                                                                   \
                 eosio::eosio_exit(1);                                                                                  \
             }                                                                                                          \

--- a/sdk/include/game-contract-sdk/dispatcher.hpp
+++ b/sdk/include/game-contract-sdk/dispatcher.hpp
@@ -38,6 +38,7 @@ bool execute_action(eosio::name self, eosio::name code, void (game::*func)(Args.
 
 } // namespace game_sdk
 
+#ifdef IS_DEBUG
 #define GAME_CONTRACT(TYPE)                                                                                            \
     extern "C" {                                                                                                       \
     void apply(uint64_t receiver, uint64_t code, uint64_t action) {                                                    \
@@ -65,6 +66,10 @@ bool execute_action(eosio::name self, eosio::name code, void (game::*func)(Args.
                 break;                                                                                                 \
             case "pushnrandom"_n.value:                                                                                \
                 game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::push_next_random);     \
+                break;                                                                                                 \
+            case "pushprng"_n.value:                                                                                   \
+                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::push_to_prng);         \
+                break;                                                                                                 \
             default:                                                                                                   \
                 eosio::eosio_exit(1);                                                                                  \
             }                                                                                                          \
@@ -72,3 +77,37 @@ bool execute_action(eosio::name self, eosio::name code, void (game::*func)(Args.
         eosio::eosio_exit(0);                                                                                          \
     }                                                                                                                  \
     }
+#else
+#define GAME_CONTRACT(TYPE)                                                                                            \
+    extern "C" {                                                                                                       \
+    void apply(uint64_t receiver, uint64_t code, uint64_t action) {                                                    \
+        if (code == "eosio.token"_n.value && action == "transfer"_n.value) {                                           \
+            game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::on_transfer);              \
+        } else if (code == receiver) {                                                                                 \
+            switch (action) {                                                                                          \
+            case "init"_n.value:                                                                                       \
+                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::init);                 \
+                break;                                                                                                 \
+            case "newgame"_n.value:                                                                                    \
+                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::new_game);             \
+                break;                                                                                                 \
+            case "gameaction"_n.value:                                                                                 \
+                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::game_action);          \
+                break;                                                                                                 \
+            case "sgdicefirst"_n.value:                                                                                \
+                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::signidice_part_1);     \
+                break;                                                                                                 \
+            case "sgdicesecond"_n.value:                                                                               \
+                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::signidice_part_2);     \
+                break;                                                                                                 \
+            case "close"_n.value:                                                                                      \
+                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::close);                \
+                break;                                                                                                 \
+            default:                                                                                                   \
+                eosio::eosio_exit(1);                                                                                  \
+            }                                                                                                          \
+        }                                                                                                              \
+        eosio::eosio_exit(0);                                                                                          \
+    }                                                                                                                  \
+    }
+#endif

--- a/sdk/include/game-contract-sdk/dispatcher.hpp
+++ b/sdk/include/game-contract-sdk/dispatcher.hpp
@@ -39,45 +39,17 @@ bool execute_action(eosio::name self, eosio::name code, void (game::*func)(Args.
 } // namespace game_sdk
 
 #ifdef IS_DEBUG
-#define GAME_CONTRACT(TYPE)                                                                                            \
-    extern "C" {                                                                                                       \
-    void apply(uint64_t receiver, uint64_t code, uint64_t action) {                                                    \
-        if (code == "eosio.token"_n.value && action == "transfer"_n.value) {                                           \
-            game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::on_transfer);              \
-        } else if (code == receiver) {                                                                                 \
-            switch (action) {                                                                                          \
-            case "init"_n.value:                                                                                       \
-                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::init);                 \
-                break;                                                                                                 \
-            case "newgame"_n.value:                                                                                    \
-                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::new_game);             \
-                break;                                                                                                 \
-            case "gameaction"_n.value:                                                                                 \
-                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::game_action);          \
-                break;                                                                                                 \
-            case "sgdicefirst"_n.value:                                                                                \
-                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::signidice_part_1);     \
-                break;                                                                                                 \
-            case "sgdicesecond"_n.value:                                                                               \
-                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::signidice_part_2);     \
-                break;                                                                                                 \
-            case "close"_n.value:                                                                                      \
-                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::close);                \
-                break;                                                                                                 \
-            case "pushnrandom"_n.value:                                                                                \
-                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::push_next_random);     \
-                break;                                                                                                 \
-            case "pushprng"_n.value:                                                                                   \
-                game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::push_to_prng);         \
-                break;                                                                                                 \
-            default:                                                                                                   \
-                eosio::eosio_exit(1);                                                                                  \
-            }                                                                                                          \
-        }                                                                                                              \
-        eosio::eosio_exit(0);                                                                                          \
-    }                                                                                                                  \
-    }
+#define EXTRA_CHECK(TYPE)                                                                                      \
+    case "pushnrandom"_n.value:                                                                                \
+        game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::push_next_random);     \
+        break;                                                                                                 \
+    case "pushprng"_n.value:                                                                                   \
+        game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::push_to_prng);         \
+        break;
 #else
+#define EXTRA_CHECK(TYPE)
+#endif
+
 #define GAME_CONTRACT(TYPE)                                                                                            \
     extern "C" {                                                                                                       \
     void apply(uint64_t receiver, uint64_t code, uint64_t action) {                                                    \
@@ -103,6 +75,7 @@ bool execute_action(eosio::name self, eosio::name code, void (game::*func)(Args.
             case "close"_n.value:                                                                                      \
                 game_sdk::execute_action<TYPE>(eosio::name(receiver), eosio::name(code), &TYPE::close);                \
                 break;                                                                                                 \
+            EXTRA_CHECK(TYPE)                                                                                          \
             default:                                                                                                   \
                 eosio::eosio_exit(1);                                                                                  \
             }                                                                                                          \
@@ -110,4 +83,3 @@ bool execute_action(eosio::name self, eosio::name code, void (game::*func)(Args.
         eosio::eosio_exit(0);                                                                                          \
     }                                                                                                                  \
     }
-#endif

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -122,7 +122,7 @@ class game : public eosio::contract {
 
     /* debug table */
     struct [[eosio::table("debug"), eosio::contract("game")]] debug_table {
-        std::list<checksum256> pseudo_queue;
+        std::vector<checksum256> pseudo_queue;
     };
 
     using debug_singleton = eosio::singleton<"debug"_n, debug_table>;
@@ -441,8 +441,8 @@ class game : public eosio::contract {
         });
 
     if (auto& pseudo_queue = global_debug.pseudo_queue; !pseudo_queue.empty()) {
-        const checksum256 new_digest = pseudo_queue.front();
-        pseudo_queue.pop_front();
+        const checksum256 new_digest = pseudo_queue.back();
+        pseudo_queue.pop_back();
         on_random(ses_id, new_digest);
         return;
     }

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -295,8 +295,9 @@ class game : public eosio::contract {
     }
 
 #ifdef IS_DEBUG
-    void push_next_random(checksum256 && next_random) {
-        global_debug.pseudo_queue.push_back(next_random);
+    CONTRACT_ACTION(pushnrandom)
+    void push_next_random(std::array<uint64_t, 4> && next_random) {
+        global_debug.pseudo_queue.emplace_back(checksum256(next_random));
     }
 #endif
 
@@ -451,12 +452,12 @@ class game : public eosio::contract {
         });
 
 #ifdef IS_DEBUG
-        if (auto& pseudo_queue = global_debug.pseudo_queue; !pseudo_queue.empty()) {
-            const checksum256 new_digest = pseudo_queue.front();
-            pseudo_queue.pop_front();
-            on_random(ses_id, new_digest);
-            return;
-        }
+    if (auto& pseudo_queue = global_debug.pseudo_queue; !pseudo_queue.empty()) {
+        const checksum256 new_digest = pseudo_queue.front();
+        pseudo_queue.pop_front();
+        on_random(ses_id, new_digest);
+        return;
+    }
 #endif
         on_random(ses_id, new_digest);
     }

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -373,7 +373,7 @@ class game : public eosio::contract {
     void push_to_prng(uint64_t next_random) { global_debug.pseudo_prng.push_back(next_random); }
 
     CONTRACT_ACTION(pushnrandom)
-    void push_next_random(checksum256 next_random) { global_debug.pseudo_queue.emplace_back(checksum256(next_random)); }
+    void push_next_random(checksum256 next_random) { global_debug.pseudo_queue.push_back(next_random); }
 #endif
 
     /* contract actions */

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -372,9 +372,6 @@ class game : public eosio::contract {
         const auto game_params = fetch_game_params(casino_id);
         const auto init_digest = calc_seed(casino_id, session.ses_seq, session.player);
 
-<<<<<<<<< Temporary merge branch 1
-        sessions.modify(session, get_self(), [&](auto& obj) {
-=========
         // always be careful with ref after modify
         // ref will still life but refer to object without new updates
         sessions.modify(session, get_self(), [&](auto& obj) {

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -23,6 +23,8 @@
 #define CONTRACT_ACTION(act_name)
 #endif
 
+#define IS_DEBUG true
+
 namespace game_sdk {
 
 using bytes = std::vector<char>;
@@ -119,6 +121,15 @@ class game : public eosio::contract {
     };
     using global_singleton = eosio::singleton<"global"_n, global_row>;
 
+#ifdef IS_DEBUG
+    /* debug table */
+    struct [[eosio::table("debug"), eosio::contract("game")]] debug_table {
+        std::queue<checksum256> pseudo_queue;
+    };
+
+    using debug_singleton = eosio::singleton<"debug"_n, debug_table>;
+#endif
+
     /* session struct */
     // clang-format off
     struct [[eosio::table("session"), eosio::contract("game")]] session_row {
@@ -144,11 +155,18 @@ class game : public eosio::contract {
         : contract(receiver, code, ds), sessions(_self, _self.value) {
         // load global singleton to memory
         global = global_singleton(_self, _self.value).get_or_default();
+
+#ifdef IS_DEBUG
+        global_debug = debug_singleton(_self, _self.value).get_or_default();
+#endif
     }
 
     virtual ~game() {
         // store singleton after all operations
         global_singleton(_self, _self.value).set(global, _self);
+#ifdef IS_DEBUG
+        debug_singleton(_self, _self.value).set(global_debug, _self);
+#endif
     }
 
   protected:
@@ -173,6 +191,10 @@ class game : public eosio::contract {
     // Getters
     // =============================================================
     const global_row& get_global() const { return global; }
+
+#ifdef IS_DEBUG
+    const debug_table& get_debug() const { return global_debug; }
+#endif
 
     const session_row& get_session(uint64_t ses_id) const {
         return sessions.get(ses_id, "session with this ses_id not found");
@@ -271,6 +293,12 @@ class game : public eosio::contract {
 
         on_finish(current_session);
     }
+
+#ifdef IS_DEBUG
+    void push_next_random(checksum256 && next_random) {
+        global_debug.pseudo_queue.push(next_random);
+    }
+#endif
 
     // new_max_win - total payout including deposit
     void update_max_win(asset new_max_win) {
@@ -422,6 +450,14 @@ class game : public eosio::contract {
             obj.last_update = eosio::current_time_point();
         });
 
+#ifdef IS_DEBUG
+        if (auto& pseudo_queue = global_debug.pseudo_queue; !pseudo_queue.empty()) {
+            const checksum256 new_digest = pseudo_queue.front();
+            pseudo_queue.pop();
+            on_random(ses_id, new_digest);
+            return;
+        }
+#endif
         on_random(ses_id, new_digest);
     }
 
@@ -482,6 +518,10 @@ class game : public eosio::contract {
     session_table sessions;
     global_row global;
     uint64_t current_session; // id of session for which was called action
+
+#ifdef IS_DEBUG
+    debug_table global_debug;
+#endif
 
   private:
     template <typename Event> void emit_event(const session_row& ses, const Event& event) {

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -440,13 +440,13 @@ class game : public eosio::contract {
             obj.last_update = eosio::current_time_point();
         });
 
-    if (auto& pseudo_queue = global_debug.pseudo_queue; !pseudo_queue.empty()) {
-        const checksum256 new_digest = pseudo_queue.back();
-        pseudo_queue.pop_back();
-        on_random(ses_id, new_digest);
-        return;
-    }
-        on_random(ses_id, new_digest);
+        if (auto& pseudo_queue = global_debug.pseudo_queue; !pseudo_queue.empty()) {
+            const checksum256 new_digest = pseudo_queue.back();
+            pseudo_queue.pop_back();
+            on_random(ses_id, new_digest);
+        } else  {
+            on_random(ses_id, new_digest);
+        }
     }
 
     CONTRACT_ACTION(close)

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -285,11 +285,6 @@ class game : public eosio::contract {
         on_finish(current_session);
     }
 
-    CONTRACT_ACTION(pushnrandom)
-    void push_next_random(std::array<uint64_t, 4> && next_random) {
-        global_debug.pseudo_queue.emplace_back(checksum256(next_random));
-    }
-
     // new_max_win - total payout including deposit
     void update_max_win(asset new_max_win) {
         const auto& session = get_session(current_session);
@@ -344,6 +339,11 @@ class game : public eosio::contract {
                 row.state = static_cast<uint8_t>(state::req_action);
             });
         }
+    }
+
+    CONTRACT_ACTION(pushnrandom)
+    void push_next_random(checksum256 next_random) {
+        global_debug.pseudo_queue.emplace_back(checksum256(next_random));
     }
 
     /* contract actions */

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -124,7 +124,7 @@ class game : public eosio::contract {
 #ifdef IS_DEBUG
     /* debug table */
     struct [[eosio::table("debug"), eosio::contract("game")]] debug_table {
-        std::queue<checksum256> pseudo_queue;
+        std::list<checksum256> pseudo_queue;
     };
 
     using debug_singleton = eosio::singleton<"debug"_n, debug_table>;
@@ -296,7 +296,7 @@ class game : public eosio::contract {
 
 #ifdef IS_DEBUG
     void push_next_random(checksum256 && next_random) {
-        global_debug.pseudo_queue.push(next_random);
+        global_debug.pseudo_queue.push_back(next_random);
     }
 #endif
 
@@ -453,7 +453,7 @@ class game : public eosio::contract {
 #ifdef IS_DEBUG
         if (auto& pseudo_queue = global_debug.pseudo_queue; !pseudo_queue.empty()) {
             const checksum256 new_digest = pseudo_queue.front();
-            pseudo_queue.pop();
+            pseudo_queue.pop_front();
             on_random(ses_id, new_digest);
             return;
         }

--- a/sdk/include/game-contract-sdk/service.hpp
+++ b/sdk/include/game-contract-sdk/service.hpp
@@ -4,15 +4,18 @@
 #include <type_traits>
 
 #include <eosio/eosio.hpp>
+#include <vector>
 
 namespace service {
 using eosio::checksum256;
 
-template <typename T, class = std::enable_if_t<std::is_unsigned<T>::value>> T cut_to(const checksum256& input) {
+template <typename T, class = std::enable_if_t<std::is_unsigned<T>::value>>
+T cut_to(const checksum256& input) {
     return cut_to<uint128_t>(input) % std::numeric_limits<T>::max();
 }
 
-template <> uint128_t cut_to(const checksum256& input) {
+template <>
+uint128_t cut_to(const checksum256& input) {
     const auto& parts = input.get_array();
     const uint128_t left = parts[0] % std::numeric_limits<uint64_t>::max();
     const uint128_t right = parts[1] % std::numeric_limits<uint64_t>::max();
@@ -31,19 +34,23 @@ std::array<uint64_t, 4> split(const checksum256& raw) {
     };
 }
 
+struct PRNG {
+    using Ptr = std::shared_ptr<PRNG>;
+
+    virtual ~PRNG();
+    virtual uint64_t next() = 0;
+};
+
 // xoshiro256++ prng algo
 // http://prng.di.unimi.it/
-class PRNG {
+class Xoshiro: public PRNG {
   public:
-    explicit PRNG(const checksum256& seed) : _s(split(seed)) {}
+    explicit Xoshiro(const checksum256& seed) : _s(split(seed)) {}
+    explicit Xoshiro(checksum256&& seed) : _s(split(std::move(seed))) {}
+    explicit Xoshiro(std::array<uint64_t, 4>&& seed) : _s(std::move(seed)) {}
+    explicit Xoshiro(const std::array<uint64_t, 4>& seed) : _s(seed) {}
 
-    explicit PRNG(checksum256&& seed) : _s(split(std::move(seed))) {}
-
-    explicit PRNG(std::array<uint64_t, 4>&& seed) : _s(std::move(seed)) {}
-
-    explicit PRNG(const std::array<uint64_t, 4>& seed) : _s(seed) {}
-
-    uint64_t next() {
+    uint64_t next() override {
         const uint64_t result = roll_up(_s[0] + _s[3], 23) + _s[0];
 
         const uint64_t t = _s[1] << 17;
@@ -69,17 +76,33 @@ class PRNG {
     std::array<uint64_t, 4> _s;
 };
 
+class PseudoPRNG: public PRNG {
+public:
+    PseudoPRNG(const std::vector<uint64_t>& values) :_values(values), _current(_values.begin()) {}
+
+    uint64_t next() override {
+        uint64_t result = *_current++;
+        if (_current == _values.end())
+            _current = _values.begin();
+        return result;
+    }
+
+private:
+    std::vector<uint64_t> _values;
+    std::vector<uint64_t>::iterator _current;
+};
+
 template <class RandomIt>
-void shuffle(RandomIt first, RandomIt last, PRNG && prng) {
+void shuffle(RandomIt first, RandomIt last, PRNG::Ptr && prng) {
     shuffle(first, last, prng);
 }
 
 template <class RandomIt>
-void shuffle(RandomIt first, RandomIt last, PRNG & prng) {
+void shuffle(RandomIt first, RandomIt last, PRNG::Ptr & prng) {
     typename std::iterator_traits<RandomIt>::difference_type i, n;
     n = last - first;
     for (i = n - 1; i > 0; --i) {
-        std::swap(first[i], first[prng.next() % (i+1)]);
+        std::swap(first[i], first[prng->next() % (i+1)]);
     }
 }
 

--- a/sdk/include/game-contract-sdk/service.hpp
+++ b/sdk/include/game-contract-sdk/service.hpp
@@ -9,13 +9,11 @@
 namespace service {
 using eosio::checksum256;
 
-template <typename T, class = std::enable_if_t<std::is_unsigned<T>::value>>
-T cut_to(const checksum256& input) {
+template <typename T, class = std::enable_if_t<std::is_unsigned<T>::value>> T cut_to(const checksum256& input) {
     return cut_to<uint128_t>(input) % std::numeric_limits<T>::max();
 }
 
-template <>
-uint128_t cut_to(const checksum256& input) {
+template <> uint128_t cut_to(const checksum256& input) {
     const auto& parts = input.get_array();
     const uint128_t left = parts[0] % std::numeric_limits<uint64_t>::max();
     const uint128_t right = parts[1] % std::numeric_limits<uint64_t>::max();
@@ -43,7 +41,7 @@ struct PRNG {
 
 // xoshiro256++ prng algo
 // http://prng.di.unimi.it/
-class Xoshiro: public PRNG {
+class Xoshiro : public PRNG {
   public:
     explicit Xoshiro(const checksum256& seed) : _s(split(seed)) {}
     explicit Xoshiro(checksum256&& seed) : _s(split(std::move(seed))) {}
@@ -76,9 +74,9 @@ class Xoshiro: public PRNG {
     std::array<uint64_t, 4> _s;
 };
 
-class PseudoPRNG: public PRNG {
-public:
-    PseudoPRNG(const std::vector<uint64_t>& values) :_values(values), _current(_values.begin()) {}
+class PseudoPRNG : public PRNG {
+  public:
+    PseudoPRNG(const std::vector<uint64_t>& values) : _values(values), _current(_values.begin()) {}
 
     uint64_t next() override {
         uint64_t result = *_current++;
@@ -87,22 +85,18 @@ public:
         return result;
     }
 
-private:
+  private:
     std::vector<uint64_t> _values;
     std::vector<uint64_t>::iterator _current;
 };
 
-template <class RandomIt>
-void shuffle(RandomIt first, RandomIt last, PRNG::Ptr && prng) {
-    shuffle(first, last, prng);
-}
+template <class RandomIt> void shuffle(RandomIt first, RandomIt last, PRNG::Ptr&& prng) { shuffle(first, last, prng); }
 
-template <class RandomIt>
-void shuffle(RandomIt first, RandomIt last, PRNG::Ptr & prng) {
+template <class RandomIt> void shuffle(RandomIt first, RandomIt last, PRNG::Ptr& prng) {
     typename std::iterator_traits<RandomIt>::difference_type i, n;
     n = last - first;
     for (i = n - 1; i > 0; --i) {
-        std::swap(first[i], first[prng->next() % (i+1)]);
+        std::swap(first[i], first[prng->next() % (i + 1)]);
     }
 }
 

--- a/sdk/include/game-contract-sdk/service.hpp
+++ b/sdk/include/game-contract-sdk/service.hpp
@@ -79,7 +79,7 @@ class PseudoPRNG : public PRNG {
     PseudoPRNG(const std::vector<uint64_t>& values) : _values(values), _current(_values.begin()) {}
 
     uint64_t next() override {
-        uint64_t result = *_current++;
+        const uint64_t result = *_current++;
         if (_current == _values.end())
             _current = _values.begin();
         return result;
@@ -90,9 +90,11 @@ class PseudoPRNG : public PRNG {
     std::vector<uint64_t>::iterator _current;
 };
 
-template <class RandomIt> void shuffle(RandomIt first, RandomIt last, PRNG::Ptr&& prng) { shuffle(first, last, prng); }
+template <class RandomIt>
+void shuffle(RandomIt first, RandomIt last, PRNG::Ptr&& prng) { shuffle(first, last, prng); }
 
-template <class RandomIt> void shuffle(RandomIt first, RandomIt last, PRNG::Ptr& prng) {
+template <class RandomIt>
+void shuffle(RandomIt first, RandomIt last, PRNG::Ptr& prng) {
     typename std::iterator_traits<RandomIt>::difference_type i, n;
     n = last - first;
     for (i = n - 1; i > 0; --i) {

--- a/tester/include/game_tester/game_tester.hpp
+++ b/tester/include/game_tester/game_tester.hpp
@@ -324,41 +324,26 @@ class game_tester : public TESTER {
         }
 
         // format-clang off
-        BOOST_REQUIRE_EQUAL(
-            push_action(
-                game_name,
-                N(gameaction),
-                {player, N(game)},
-                {platform_name, N(active)},
-                mvo()
-                    ("req_id", ses_id)
-                    ("type", action_type)
-                    ("params", params)
-            ), success());
+        BOOST_REQUIRE_EQUAL(push_action(game_name,
+                                        N(gameaction),
+                                        {player, N(game)},
+                                        {platform_name, N(active)},
+                                        mvo()("req_id", ses_id)("type", action_type)("params", params)),
+                            success());
         // format-clang on
     }
 
 #ifdef IS_DEBUG
-    void push_next_random(name game_name, sha256 && next_random) {
+    void push_next_random(name game_name, sha256&& next_random) {
         BOOST_REQUIRE_EQUAL(
-            push_action(
-                game_name,
-                N(pushnrandom),
-                {platform_name, N(active)},
-                mvo()
-                    ("next_random", next_random)
-            ), success());
+            push_action(game_name, N(pushnrandom), {platform_name, N(active)}, mvo()("next_random", next_random)),
+            success());
     }
 
-    void push_to_prng(name game_name, uint64_t && next_random) {
+    void push_to_prng(name game_name, uint64_t&& next_random) {
         BOOST_REQUIRE_EQUAL(
-            push_action(
-                game_name,
-                N(pushprng),
-                {platform_name, N(active)},
-                mvo()
-                    ("next_random", next_random)
-            ), success());
+            push_action(game_name, N(pushprng), {platform_name, N(active)}, mvo()("next_random", next_random)),
+            success());
     }
 #endif
 

--- a/tester/include/game_tester/game_tester.hpp
+++ b/tester/include/game_tester/game_tester.hpp
@@ -338,7 +338,6 @@ class game_tester : public TESTER {
         // format-clang on
     }
 
-#ifdef IS_DEBUG
     void push_next_random(name game_name, sha256 && next_random) {
         BOOST_REQUIRE_EQUAL(
             push_action(
@@ -349,7 +348,6 @@ class game_tester : public TESTER {
                     ("next_random", next_random)
             ), success());
     }
-#endif
 
     void signidice(name game_name, uint64_t ses_id) {
         auto digest = get_game_session(game_name, ses_id)["digest"].as<sha256>();

--- a/tester/include/game_tester/game_tester.hpp
+++ b/tester/include/game_tester/game_tester.hpp
@@ -338,16 +338,29 @@ class game_tester : public TESTER {
         // format-clang on
     }
 
+#ifdef IS_DEBUG
     void push_next_random(name game_name, sha256 && next_random) {
         BOOST_REQUIRE_EQUAL(
             push_action(
                 game_name,
                 N(pushnrandom),
-                {platform_name, N(signidice)},
+                {platform_name, N(active)},
                 mvo()
                     ("next_random", next_random)
             ), success());
     }
+
+    void push_to_prng(name game_name, uint64_t && next_random) {
+        BOOST_REQUIRE_EQUAL(
+            push_action(
+                game_name,
+                N(pushprng),
+                {platform_name, N(active)},
+                mvo()
+                    ("next_random", next_random)
+            ), success());
+    }
+#endif
 
     void signidice(name game_name, uint64_t ses_id) {
         auto digest = get_game_session(game_name, ses_id)["digest"].as<sha256>();

--- a/tester/include/game_tester/game_tester.hpp
+++ b/tester/include/game_tester/game_tester.hpp
@@ -323,37 +323,79 @@ class game_tester : public TESTER {
             transfer(player, game_name, deposit, std::to_string(ses_id));
         }
 
-        BOOST_REQUIRE_EQUAL(push_action(game_name,
-                                        N(gameaction),
-                                        {player, N(game)},
-                                        {platform_name, N(active)},
-                                        mvo()("req_id", ses_id)("type", action_type)("params", params)),
-                            success());
+        // format-clang off
+        BOOST_REQUIRE_EQUAL(
+            push_action(
+                game_name,
+                N(gameaction),
+                {player, N(game)},
+                {platform_name, N(active)},
+                mvo()
+                    ("req_id", ses_id)
+                    ("type", action_type)
+                    ("params", params)
+            ), success());
+        // format-clang on
     }
+
+#ifdef IS_DEBUG
+    void push_next_random(name game_name, sha256 && next_random) {
+        BOOST_REQUIRE_EQUAL(
+            push_action(
+                game_name,
+                N(pushnrandom),
+                {platform_name, N(signidice)},
+                mvo()
+                    ("next_random", next_random)
+            ), success());
+    }
+#endif
 
     void signidice(name game_name, uint64_t ses_id) {
         auto digest = get_game_session(game_name, ses_id)["digest"].as<sha256>();
 
         auto sign_1 = rsa_sign(rsa_keys.at(platform_name), digest);
+        // clang-format off
         BOOST_REQUIRE_EQUAL(
             push_action(
-                game_name, N(sgdicefirst), {platform_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_1)),
-            success());
+                game_name,
+                N(sgdicefirst),
+                {platform_name, N(signidice)},
+                mvo()
+                    ("req_id", ses_id)
+                    ("sign", sign_1)
+            ), success());
+        // clang-format on
 
         BOOST_REQUIRE_EQUAL(get_game_session(game_name, ses_id)["digest"].as<sha256>(), sha256::hash(sign_1));
 
         digest = get_game_session(game_name, ses_id)["digest"].as<sha256>();
 
         auto sign_2 = rsa_sign(rsa_keys.at(casino_name), digest);
+        // clang-format off
         BOOST_REQUIRE_EQUAL(
             push_action(
-                game_name, N(sgdicesecond), {casino_name, N(signidice)}, mvo()("req_id", ses_id)("sign", sign_2)),
-            success());
+                game_name,
+                N(sgdicesecond),
+                {casino_name, N(signidice)},
+                mvo()
+                    ("req_id", ses_id)
+                    ("sign", sign_2)
+            ), success());
+        // clang-format on
     }
 
     void close_session(name game_name, uint64_t ses_id) {
-        BOOST_REQUIRE_EQUAL(push_action(game_name, N(close), {platform_name, N(active)}, mvo()("req_id", ses_id)),
-                            success());
+        // clang-format off
+        BOOST_REQUIRE_EQUAL(
+            push_action(
+                game_name,
+                N(close),
+                {platform_name, N(active)},
+                mvo()
+                    ("req_id", ses_id)
+            ), success());
+        // clang-format on
     }
 
     asset get_balance(name account) const { return get_currency_balance(N(eosio.token), symbol(CORE_SYM), account); }


### PR DESCRIPTION
`IS_DEBUG` change contract abi. We have additional methods to mock `on_random` call and method to mock `get_prng` method. 

- `PRNG` from solo class to 
   - Interface
   - `Xoshiro` class
   - `PseudoPRNG` class
- Tests now process external keys (you can use `--run_test` as example)
- Debug abi stored in separated file and merge with final file only in debug mode
- All mock data stored in debug-only table