### PR TITLE
DPM-453 use daocasino/daobet-with-cdt.ubuntu:latest image

### DIFF
--- a/cicd/run
+++ b/cicd/run
@@ -2,7 +2,7 @@
 
 set -eux
 
-run_node_with_cdt_cmd="docker run --rm -v "$PWD":/build -w /build -ti daocasino/daobet-with-cdt:latest"
+run_node_with_cdt_cmd="docker run --rm -v "$PWD":/build -w /build -ti daocasino/daobet-with-cdt.ubuntu:latest"
 
 cmd="${1:?}"
 shift

--- a/sdk/scripts/gen_abi.sh
+++ b/sdk/scripts/gen_abi.sh
@@ -2,7 +2,7 @@
 
 project_root="$(realpath $(dirname "${BASH_SOURCE[0]}")/../../)"
 
-run_in_docker="docker run --rm -v "$project_root":/build -w /build -ti daocasino/daobet-with-cdt:latest"
+run_in_docker="docker run --rm -v "$project_root":/build -w /build -ti daocasino/daobet-with-cdt.ubuntu:latest"
 output="sdk/files/game.abi"
 entry="examples/stub/contracts/src/stub.cpp"
 


### PR DESCRIPTION
daocasino/daobet-with-cdt is a legacy image without debug versions of libraries.
**Will be merged after updating platform contracts version.**