### PR TITLE
[DPM-610] remove auth check from signidice actions

### DIFF
--- a/examples/proto_dice/tests/proto_dice_tests.cpp
+++ b/examples/proto_dice/tests/proto_dice_tests.cpp
@@ -371,7 +371,7 @@ BOOST_FIXTURE_TEST_CASE(deposit_bad_state_test, proto_dice_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -416,7 +416,7 @@ BOOST_FIXTURE_TEST_CASE(game_action_bad_state_test, proto_dice_tester) try {
     BOOST_REQUIRE_EQUAL(
         push_action(game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -455,7 +455,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_1_bad_state_test, proto_dice_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -467,7 +467,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_1_bad_state_test, proto_dice_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -477,7 +477,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_1_bad_state_test, proto_dice_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -504,7 +504,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_2_bad_state_test, proto_dice_tester) try {
         push_action(
             game_name,
             N(sgdicesecond),
-            {casino_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign)
@@ -516,7 +516,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_2_bad_state_test, proto_dice_tester) try {
         push_action(
             game_name,
             N(sgdicesecond),
-            {casino_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign)

--- a/examples/stub/tests/stub_tests.cpp
+++ b/examples/stub/tests/stub_tests.cpp
@@ -264,7 +264,7 @@ BOOST_FIXTURE_TEST_CASE(deposit_bad_state_test, stub_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -309,7 +309,7 @@ BOOST_FIXTURE_TEST_CASE(game_action_bad_state_test, stub_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -349,7 +349,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_1_bad_state_test, stub_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -361,7 +361,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_1_bad_state_test, stub_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -371,7 +371,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_1_bad_state_test, stub_tester) try {
         push_action(
             game_name,
             N(sgdicefirst),
-            {platform_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign_1)
@@ -400,7 +400,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_2_bad_state_test, stub_tester) try {
         push_action(
             game_name,
             N(sgdicesecond),
-            {casino_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign)
@@ -412,7 +412,7 @@ BOOST_FIXTURE_TEST_CASE(signidice_2_bad_state_test, stub_tester) try {
         push_action(
             game_name,
             N(sgdicesecond),
-            {casino_name, N(signidice)},
+            {service_name, N(active)},
             mvo()
                 ("req_id", ses_id)
                 ("sign", sign)

--- a/sdk/include/game-contract-sdk/game_base.hpp
+++ b/sdk/include/game-contract-sdk/game_base.hpp
@@ -411,12 +411,14 @@ class game : public eosio::contract {
         on_action(ses_id, type, params);
     }
 
+    /*
+     NOTE: that action dosn't check authorization by require_auth, but checks RSA sign
+    */
     CONTRACT_ACTION(sgdicefirst)
     void signidice_part_1(uint64_t ses_id, const std::string& sign) {
         set_current_session(ses_id);
         const auto& session = get_session(ses_id);
 
-        check_from_platform_signidice();
         check_not_expired(session);
         check_only_states(session, {state::req_signidice_part_1}, "state should be 'req_signidice_part_1'");
 
@@ -436,12 +438,14 @@ class game : public eosio::contract {
         emit_event(session, events::signidice_part_2_request{new_digest});
     }
 
+    /*
+     NOTE: that action dosn't check authorization by require_auth, but checks RSA sign
+    */
     CONTRACT_ACTION(sgdicesecond)
     void signidice_part_2(uint64_t ses_id, const std::string& sign) {
         set_current_session(ses_id);
         const auto& session = get_session(ses_id);
 
-        check_from_casino_signidice(session);
         check_not_expired(session);
         check_only_states(session, {state::req_signidice_part_2}, "state should be 'req_signidice_part_2'");
 
@@ -659,12 +663,6 @@ class game : public eosio::contract {
     }
 
     void check_from_platform_game() const { require_auth({get_platform(), platform_game_permission}); }
-
-    void check_from_casino_signidice(const session_row& ses) const {
-        require_auth({get_casino(ses.casino_id), casino_signidice_permission});
-    }
-
-    void check_from_platform_signidice() const { require_auth({get_platform(), platform_signidice_permission}); }
 
 #ifdef IS_DEBUG
   public:


### PR DESCRIPTION
**CHANGES:**
 - removed auth checks in signidice actions
 - after SDK update in games that can require some changes in tests:
   - need to change provided authority for signidice actions to `{service_name, N(active)}`
- also that require changes in platform-back and casino-back
   - need to change provided authority for signidice actions to any other account's active permission (that cannot be platform or casino account because they will have no active/owner permissions after listing)